### PR TITLE
contributor list corrections

### DIFF
--- a/contributors/2018.md
+++ b/contributors/2018.md
@@ -14,7 +14,6 @@
 1.  Bart Bijvoets
 1.  Kristina Birthisel
 1.  Savannah Bishop
-1.  Chris Blackwell
 1.  Christopher Blackwell
 1.  Laurel Boman
 1.  Suzan Boreel
@@ -44,9 +43,9 @@
 1.  Alex Dobens
 1.  William Dolan
 1.  Scott Dubé
+1.  Casey Dué
 1.  Hillary Duffy
 1.  Eric Dugdale
-1.  Casey Dué
 1.  Mary Ebbott
 1.  Elias Eells
 1.  Salma El Emrani
@@ -93,7 +92,6 @@
 1.  Grecia Leal Pardo
 1.  Sjors Leek
 1.  Olga Levaniouk
-1.  Olga Levanouik
 1.  Daniel Libatique
 1.  Christina Lillard
 1.  Stephanie Lindeborg
@@ -149,7 +147,6 @@
 1.  Mercedes Sisk
 1.  James Skoog
 1.  Ineke Sluiter
-1.  Inike Sluiter
 1.  Andrew Smith
 1.  Neel Smith
 1.  Deborah Sokolowski

--- a/contributors/2018.md
+++ b/contributors/2018.md
@@ -1,6 +1,7 @@
 # Homer Multitext Contributors:  2018 releases
 
 1.  Jennifer Adams
+1.  Eileen van den Akerboom
 1.  Apostolia Alepidou
 1.  Matthew Angiolillo
 1.  Grace Anthony
@@ -11,6 +12,7 @@
 1.  Adam Beckwith
 1.  Assumpta Becude
 1.  JJ Bergman
+1.  Tazuko van Berkel
 1.  Bart Bijvoets
 1.  Kristina Birthisel
 1.  Savannah Bishop
@@ -50,6 +52,7 @@
 1.  Elias Eells
 1.  Salma El Emrani
 1.  Leah Elder
+1.  Alex van Eldik
 1.  Brandon Elmy
 1.  Jennifer Facendola
 1.  James Fox
@@ -63,6 +66,7 @@
 1.  Jeffrey Godowski
 1.  Jack Goode
 1.  Karl Grant
+1.  Maike van Haeringen
 1.  Kirsten Haijes
 1.  Claude Hanley
 1.  Tucker Hannah
@@ -91,6 +95,7 @@
 1.  Nathan Kroschel
 1.  Grecia Leal Pardo
 1.  Sjors Leek
+1.  Thom van Leuveren
 1.  Olga Levaniouk
 1.  Daniel Libatique
 1.  Christina Lillard
@@ -158,6 +163,7 @@
 1.  Ian Tewksbury
 1.  Megan Truax
 1.  Solomon Umana
+1.  Bob van Velthoven
 1.  Marloes Velthuisen
 1.  Suzanne Verkade
 1.  Kimbell Vincent-Dobbins
@@ -169,9 +175,3 @@
 1.  Haley Yi
 1.  Felege-Selam Yirga
 1.  Shannon Young
-1.  Tazuko van Berkel
-1.  Alex van Eldik
-1.  Maike van Haeringen
-1.  Thom van Leuveren
-1.  Bob van Velthoven
-1.  Eileen van den Akerboom


### PR DESCRIPTION
`contributors/2018.md` corrections:
* removed misspelled duplicate names (Chris/Christopher, Levaniouk/Levanouik, Ineke/Inike)
* listed Dué before Duf*
* properly alphabetized Dutch "van" surnames